### PR TITLE
Type check creation of empty SortedDict with non-str key function

### DIFF
--- a/sortedcontainers-stubs/sorteddict.pyi
+++ b/sortedcontainers-stubs/sorteddict.pyi
@@ -86,6 +86,13 @@ class SortedDict(MutableMapping[_KT, _VT]):
     def __new__(
         cls,
         __key: KeyFunc[_KT, _OrderT],
+        /,
+        **kwargs: _VT,
+    ) -> SortedKeyDict[_KT, _VT, _OrderT]: ...
+    @overload
+    def __new__(
+        cls,
+        __key: KeyFunc[_KT, _OrderT],
         __entries: Iterable[tuple[_KT, _VT]] | SupportsKeysAndGetItem[_KT, _VT],
         /,
     ) -> SortedKeyDict[_KT, _VT, _OrderT]: ...

--- a/test/test_sorteddict.py
+++ b/test/test_sorteddict.py
@@ -50,6 +50,15 @@ def test_sorted_key_dict() -> None:
     assert not hasattr(sorted_dict, "bisect_key_left")
 
 
+def test_non_str_key_func() -> None:
+    def key_fn(tup: tuple[int, int]) -> int:
+        a, b = tup
+        return a + b
+
+    _example_empty: SortedDict[tuple[int, int], str] = SortedDict(key_fn)
+    _example: SortedDict[tuple[int, int], str] =  SortedDict(key_fn, [((1, 1), "a"), ((3, -2), "b")])
+
+
 def test_unavoidable_type_violations() -> None:
     # See SortedList's constructor (__new__()) for more on the same issue.
     # We can't constrain the key type to be hashable & orderable when no initial


### PR DESCRIPTION
Without the change, the new test would fail with:
```
$ poetry run mypy test/test_sorteddict.py
test/test_sorteddict.py:58: error: Incompatible types in assignment (expression has type "SortedKeyDict[str, str, int]", variable has type "SortedDict[tuple[int, int], str]")  [assignment]
test/test_sorteddict.py:58: error: Argument 1 to "SortedDict" has incompatible type "Callable[[tuple[int, int]], int]"; expected "Callable[[str], int]"  [arg-type]
Found 2 errors in 1 file (checked 1 source file)
```

Fixes #6